### PR TITLE
Fix episode with question marks, and improve !ep detector

### DIFF
--- a/discord_functions.py
+++ b/discord_functions.py
@@ -205,21 +205,25 @@ async def set_role(payload, user, guild, role_dict):
 Search through the wiki and find the requested episode and respond with a link to it
 """
 async def request_episode(message):
-    if message.content.lower().startswith("!ep"):
-        search_episode = message.content.lower().split("!ep")[1].strip()
-    elif message.content.startswith('!episode'):
-        search_episode = message.content.lower().split("!episode")[1].strip()
+    # content is known to begin with !ep or !episode
+    # strip off the prefix
+    content = message.content.lower()
+    rest = content[3:]
+    if (rest.startswith("isode")):
+        rest = rest[5:]
+
+    search_episode = rest.split()[0]
 
     episode_message = discord.Embed(color=0x50AE26)
 
     # If user wants to be given a random episode
-    if not str.isdigit(search_episode) and (search_episode.lower() == "random" or search_episode.lower() == "r"):
+    if not str.isdigit(search_episode) and (search_episode == "random" or search_episode == "r"):
         episode_page = search_for_random_episode()
         if episode_page is None:
             episode_message.add_field(name="ERROR", value="Could not find an episode.", inline=False)
             print("Error: Could not find a random episode")
         else:
-            episode_message.add_field(name=episode_page.title, value=episode_page.url, inline=False)
+            episode_message.add_field(name=episode_page.title, value=encode_episode_url(episode_page.url), inline=False)
             print("Found " + episode_page.title + "!")
 
     # If user wants a specific episode
@@ -229,7 +233,7 @@ async def request_episode(message):
             episode_message.add_field(name="ERROR", value="Could not find episode " + search_episode, inline=False)
             print("Error: Could not find Episode " + search_episode + ".")
         else:
-            episode_message.add_field(name=episode_page.title, value=episode_page.url, inline=False)
+            episode_message.add_field(name=episode_page.title, value=encode_episode_url(episode_page.url), inline=False)
             print("Found Episode " + search_episode + "!")
 
     # If could not query

--- a/tortuga_bot.py
+++ b/tortuga_bot.py
@@ -28,13 +28,14 @@ def run_tortuga_bot():
 
     @client.event
     async def on_message(message):
-        if message.content.lower().startswith("!remove"):
+        content = message.content.lower()
+        if content.startswith("!remove"):
             await request_delete_role(client, message)
 
-        if message.content.lower().startswith("!ep") or message.content.lower().startswith('!episode'):
+        if content.startswith("!ep"):
             await request_episode(message)
             
-        if message.content.lower().startswith("!stat"):
+        if content.startswith("!stat"):
             await try_send_metric(client, message)
 
     @client.event

--- a/wiki_functions.py
+++ b/wiki_functions.py
@@ -32,3 +32,5 @@ def search_for_random_episode():
     return episode_page
 
 
+def encode_episode_url(url):
+    return url.replace("?", "%3f")


### PR DESCRIPTION
Question marks need to be encoded in the URL because they would otherwise be interpreted as a URL query.

Also, the `!ep` detector was a little broken: The `elsif` had no effect because anything that begins with `!episode` must also begin with `!ep`.

Bonus: Ignore extra text after the episode number, so you can say

    !ep 714 This draft episode was oddly prescient.

and the bot will ignore your commentary.

Factor out some redundant `lower()` calls.
